### PR TITLE
clocksync: expose `transmit_extra` as a tunable `[danger_options]` knob

### DIFF
--- a/klippy/clocksync.py
+++ b/klippy/clocksync.py
@@ -9,7 +9,11 @@ import traceback
 
 RTT_AGE = 0.000010 / (60.0 * 60.0)
 DECAY = 1.0 / 30.0
-TRANSMIT_EXTRA = 0.001
+# Default forward-scheduling headroom added to the clock estimate sent
+# to the serialqueue.  Can be overridden via [danger_options]
+# transmit_extra.  Increase this (e.g. to 0.003-0.005) if you
+# experience 'Timer too close' shutdowns on a heavily loaded host.
+TRANSMIT_EXTRA = 0.002
 
 
 class ClockSync:
@@ -30,6 +34,11 @@ class ClockSync:
         self.clock_avg = self.clock_covariance = 0.0
         self.prediction_variance = 0.0
         self.last_prediction_time = 0.0
+        self.transmit_extra = TRANSMIT_EXTRA
+
+    def set_transmit_extra(self, value):
+        """Override the transmit_extra headroom (called from danger_options)."""
+        self.transmit_extra = value
 
     def disconnect(self):
         self.reactor.update_timer(self.get_clock_timer, self.reactor.NEVER)
@@ -145,7 +154,7 @@ class ClockSync:
         pred_stddev = math.sqrt(self.prediction_variance)
         self.serial.set_clock_est(
             new_freq,
-            self.time_avg + TRANSMIT_EXTRA,
+            self.time_avg + self.transmit_extra,
             int(self.clock_avg - 3.0 * pred_stddev),
             clock,
         )
@@ -192,7 +201,7 @@ class ClockSync:
             "clocksync state: mcu_freq=%d last_clock=%d"
             " clock_est=(%.3f %d %.3f) min_half_rtt=%.6f min_rtt_time=%.3f"
             " time_avg=%.3f(%.3f) clock_avg=%.3f(%.3f)"
-            " pred_variance=%.3f"
+            " pred_variance=%.3f transmit_extra=%.6f"
             % (
                 self.mcu_freq,
                 self.last_clock,
@@ -206,6 +215,7 @@ class ClockSync:
                 self.clock_avg,
                 self.clock_covariance,
                 self.prediction_variance,
+                self.transmit_extra,
             )
         )
 

--- a/klippy/extras/danger_options.py
+++ b/klippy/extras/danger_options.py
@@ -44,7 +44,8 @@ class DangerOptions:
         # transmit_extra: forward-scheduling headroom (seconds) added to the
         # MCU clock estimate passed to the serialqueue.  Increasing this helps
         # prevent 'Timer too close' MCU shutdowns on hosts that experience CPU
-        # or scheduling jitter.  See docs/Danger_Options.md for guidance.
+        # or scheduling jitter.  See docs/Config_Reference.md ([danger_options])
+        # for guidance.
         self.transmit_extra = config.getfloat(
             "transmit_extra", TRANSMIT_EXTRA, minval=0.0, maxval=0.010
         )

--- a/klippy/extras/danger_options.py
+++ b/klippy/extras/danger_options.py
@@ -91,7 +91,6 @@ def load_config(config):
     DANGER_OPTIONS = DangerOptions(config)
     # Apply transmit_extra to all ClockSync instances already registered
     printer = config.get_printer()
-    reactor = printer.get_reactor()
     # Wire transmit_extra into MCU clocksync objects at connect time
     printer.register_event_handler(
         "klippy:mcu_identify",

--- a/klippy/extras/danger_options.py
+++ b/klippy/extras/danger_options.py
@@ -1,3 +1,6 @@
+from ..clocksync import TRANSMIT_EXTRA
+
+
 class DangerOptions:
     def __init__(self, config):
         self.minimal_logging = config.getboolean("minimal_logging", False)
@@ -37,6 +40,13 @@ class DangerOptions:
         )
         self.homing_elapsed_distance_tolerance = config.getfloat(
             "homing_elapsed_distance_tolerance", 0.5, minval=0.0
+        )
+        # transmit_extra: forward-scheduling headroom (seconds) added to the
+        # MCU clock estimate passed to the serialqueue.  Increasing this helps
+        # prevent 'Timer too close' MCU shutdowns on hosts that experience CPU
+        # or scheduling jitter.  See docs/Danger_Options.md for guidance.
+        self.transmit_extra = config.getfloat(
+            "transmit_extra", TRANSMIT_EXTRA, minval=0.0, maxval=0.010
         )
 
         temp_ignore_limits = False
@@ -78,4 +88,21 @@ def get_danger_options():
 def load_config(config):
     global DANGER_OPTIONS
     DANGER_OPTIONS = DangerOptions(config)
+    # Apply transmit_extra to all ClockSync instances already registered
+    printer = config.get_printer()
+    reactor = printer.get_reactor()
+    # Wire transmit_extra into MCU clocksync objects at connect time
+    printer.register_event_handler(
+        "klippy:mcu_identify",
+        lambda: _apply_transmit_extra(printer, DANGER_OPTIONS.transmit_extra),
+    )
     return DANGER_OPTIONS
+
+
+def _apply_transmit_extra(printer, value):
+    """Push transmit_extra into all MCU clocksync objects."""
+    for name, obj in printer.objects.items():
+        if name == "mcu" or name.startswith("mcu "):
+            clocksync = getattr(obj, "_clocksync", None)
+            if clocksync is not None and hasattr(clocksync, "set_transmit_extra"):
+                clocksync.set_transmit_extra(value)


### PR DESCRIPTION
## Problem

When the host computer is under CPU or scheduling pressure, the `MCU 'X' shutdown: Timer too close` error can occur across multiple MCUs simultaneously. This happens because `TRANSMIT_EXTRA` in `clocksync.py` — the fixed 1 ms forward-scheduling headroom added to the MCU clock estimate passed to the serialqueue — is too small to absorb the host's scheduling jitter. The MCU then receives a command whose scheduled waketime has already passed, triggering the hard `try_shutdown("Timer too close")` guard in `src/sched.c`.

Because the error originates on the klippy/host side (not in MCU firmware), this is safely fixable without reflashing.

## Changes

### `klippy/clocksync.py`
- Increased the `TRANSMIT_EXTRA` module-level default from `0.001` s → **`0.002` s**.
- Added `self.transmit_extra` instance attribute (initialized from the module default) so each `ClockSync` / `SecondarySync` object can be overridden independently.
- Added `set_transmit_extra(value)` method so `danger_options` can push a user-supplied value in at connect time.
- `_handle_clock()` now uses `self.transmit_extra` instead of the bare `TRANSMIT_EXTRA` constant.
- `dump_debug()` now includes `transmit_extra` in its output to aid diagnostics.

### `klippy/extras/danger_options.py`
- Added `transmit_extra` config option (`minval=0.0`, `maxval=0.010`, default sourced from `clocksync.TRANSMIT_EXTRA`).
- Registers a `klippy:mcu_identify` event handler that walks all MCU objects and calls `set_transmit_extra()` on each `_clocksync`, so a single config line applies to every MCU (primary + secondary/CAN).

## Tuning Guide for End Users

Add to `printer.cfg`:

```ini
[danger_options]
transmit_extra: 0.002   # seconds; default
```

| Scenario | Recommended value |
|---|---|
| Dedicated quiet host (CB1/CM4, nothing else running) | `0.001` |
| Default / lightly loaded host | `0.002` |
| Shared host with background services | `0.003` – `0.004` |
| CAN-bus multi-MCU setups with added bus latency | `0.003` – `0.005` |
| Severely overloaded or high-latency host | `0.005` – `0.010` |

Values above `0.010` s are capped by `maxval` and are not recommended — they push commands so far ahead that scheduling latency for reactive events (endstops, probes) could be marginally affected, though step timing accuracy and print quality are not impacted at normal values.

**Do not** increase `transmit_extra` as a substitute for fixing the underlying host load issue. If you need values above `0.004` consistently, investigate CPU usage, swap, disk I/O, or thermal throttling on the host.

## Safety

The MCU-side `Timer too close` guard in `src/sched.c` is **not modified**. It is a hard safety check that must remain intact. All changes are confined to the host-side Python layer.