### PR TITLE
klippy: lock process memory to RAM at startup via mlockall

### DIFF
--- a/klippy/printer.py
+++ b/klippy/printer.py
@@ -666,6 +666,7 @@ def main():
         logging.getLogger().setLevel(debuglevel)
     logging.info("=======================")
     logging.info("Starting Klippy...")
+    util.lock_memory()
     git_info = util.get_git_version()
     git_vers = git_info["version"]
 

--- a/klippy/util.py
+++ b/klippy/util.py
@@ -3,6 +3,8 @@
 # Copyright (C) 2016-2020  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+import ctypes
+import ctypes.util
 import fcntl
 import json
 import logging
@@ -25,6 +27,24 @@ def fix_sigint():
 
 
 fix_sigint()
+
+
+# Lock all current and future memory pages into RAM to prevent swapping
+def lock_memory():
+    MCL_CURRENT = 1
+    MCL_FUTURE = 2
+    try:
+        libc = ctypes.CDLL("libc.so.6", use_errno=True)
+        result = libc.mlockall(MCL_CURRENT | MCL_FUTURE)
+        if result != 0:
+            errno_val = ctypes.get_errno()
+            raise OSError(errno_val, os.strerror(errno_val))
+        logging.info(
+            "Memory locked to RAM (mlockall MCL_CURRENT|MCL_FUTURE):"
+            " swapping disabled"
+        )
+    except Exception as e:
+        logging.warning("Failed to lock memory: %s", e)
 
 
 # Set a file-descriptor as non-blocking


### PR DESCRIPTION
## Summary

Call `mlockall(MCL_CURRENT | MCL_FUTURE)` once, immediately after logging is initialised in `main()`. This pins all current and future Klippy memory pages into physical RAM for the lifetime of the process.

## Motivation

Klippy is a real-time-sensitive host process: it must issue step commands to the MCU on tight, predictable schedules. When the Linux kernel is under memory pressure it can swap out process pages and fault them back in on access. Those page faults introduce multi-millisecond latency spikes that are difficult to attribute and can cause:

- missed steps / timing errors
- false "Communication timeout" shutdowns
- subtle under-extrusion or layer shifts under load

Locking memory is a standard technique used by audio servers (JACK, PipeWire), RTOS wrappers, and other latency-sensitive Linux processes for exactly this reason.

## Flags

| Flag | Meaning |
|------|---------|
| `MCL_CURRENT` | Lock all pages already mapped at call time |
| `MCL_FUTURE` | Lock all pages mapped after the call (stack growth, dlopen, mmap) |

## Capability requirement

`mlockall` requires `CAP_IPC_LOCK` (or root). On typical Klipper/Kalico deployments the process runs as a privileged service user that already holds this capability. If the capability is absent the failure is **logged as a warning** and Klippy continues normally, so development environments and containers that do not grant the capability are unaffected.

## Implementation

- `klippy/util.py` — new `lock_memory()` helper, placed next to other low-level Unix utilities (`fix_sigint`, `create_pty`, etc.)
- `klippy/printer.py` — one-line call to `util.lock_memory()` in `main()` right after `logging.info("Starting Klippy...")`

No new dependencies; uses the standard library `ctypes` module to call into `libc.so.6`.