### PR TITLE
load_cell_fusion: clear sensor update flags after report

### DIFF
--- a/src/load_cell_fusion.c
+++ b/src/load_cell_fusion.c
@@ -143,6 +143,14 @@ load_cell_fusion_report_sample(struct load_cell_fusion_sensor *lcfs,
 }
 
 static void
+clear_sensor_updates(struct load_cell_fusion *lcf)
+{
+    uint8_t i;
+    for (i = 0; i < lcf->sensor_count; i++)
+        lcf->sensors[i].updated = 0;
+}
+
+static void
 load_cell_fusion_process_group(struct load_cell_fusion *lcf)
 {
     if (!lcf->active || !lcf->dirty)
@@ -160,6 +168,7 @@ load_cell_fusion_process_group(struct load_cell_fusion *lcf)
     for (i = 0; i < lcf->sensor_count; i++) {
         if (lcf->sensors[i].has_error) {
             add_sample(&lcf->sb, lcf->oid, lcf->sensors[i].last_sample);
+            clear_sensor_updates(lcf);
             return;
         }
     }
@@ -172,6 +181,7 @@ load_cell_fusion_process_group(struct load_cell_fusion *lcf)
     add_sample(&lcf->sb, lcf->oid, (uint32_t)fused);
     if (lcf->lce)
         load_cell_probe_report_sample(lcf->lce, fused);
+    clear_sensor_updates(lcf);
 }
 
 void


### PR DESCRIPTION
 Summary

Fix `load_cell_fusion` so each fused sample requires a fresh update from every attached sensor.

Previously, once all fusion sensors had reported at least once, their `updated` flags stayed latched. After that, any single sensor update could cause a new fused sample to be emitted using fresh data from one sensor and stale data from the others.

This clears the per-sensor `updated` flags after reporting either a normal fused sample or an error sample.
 Why

This keeps fusion output synchronized to complete sensor groups instead of emitting at the combined per-channel update rate after warm-up. For multi-sensor HX711 fusion, that prevents over-reporting and stale-channel fusion samples.

this is diag and will effectively disable the 320hz poll and force 80hz effective DO NOT USE other then for testing
Testing

Not runtime tested. Firmware build/test needed on target MCU.
HERE BE DRAGONS THIS MAY KILL YOUR PETS, SET YOUR HOUSE ON FIRE AND OR BRICK YOUR BED!